### PR TITLE
feat(patient): add pediatric age validation and update form handling

### DIFF
--- a/src/app/patient_form.tsx
+++ b/src/app/patient_form.tsx
@@ -16,6 +16,7 @@ import {
   ParentRelation,
   parentSchema,
   Sex,
+  UpdatePatientDTO,
 } from '@/models/schemas';
 import * as v from 'valibot';
 import { useAddPatientViewModal } from '@/hooks/useAddPatientViewModel';
@@ -78,7 +79,17 @@ export default function AddOrUpdatePatient() {
         <DynamicForm
           {...props}
           sections={addPatientFormConfig}
-          onSubmit={(data) => (isUpdate ? updatePatient(id, data as any) : addPatient(data as any))}
+          onSubmit={(data) => {
+            if (isUpdate) {
+              updatePatient(id, data as UpdatePatientDTO);
+              console.log('Patient updated successfully');
+              router.back();
+            } else {
+              addPatient(data as CreatePatientDTO);
+              console.log('Patient added successfully');
+              router.back();
+            }
+          }}
           transformData={transformData}
           outputSchema={createPatientSchema}
           {...{

--- a/src/hooks/useAddPatientViewModel.ts
+++ b/src/hooks/useAddPatientViewModel.ts
@@ -1,4 +1,4 @@
-import { MAX_AGE_IN_MONTH_IN_PEDIATRIC } from '@/constants';
+import { DAY_IN_MONTHS, MAX_AGE_IN_MONTH_IN_PEDIATRIC } from '@/constants';
 import { PatientHelpers } from '@/models/helpers';
 import { CreatePatientDTO } from '@/models/schemas';
 import { modeles$ } from '@/store';
@@ -11,7 +11,7 @@ export function useAddPatientViewModal() {
     try {
       setIsLoading(true);
       const newPatient = PatientHelpers.create(input);
-      if (PatientHelpers.getAgeInDay(newPatient) > MAX_AGE_IN_MONTH_IN_PEDIATRIC) {
+      if (PatientHelpers.getAgeInDay(newPatient) / DAY_IN_MONTHS > MAX_AGE_IN_MONTH_IN_PEDIATRIC) {
         throw new Error('Ce patient ne peux être enrégistré en pediatrie');
       }
       modeles$.patients[newPatient.id].set(newPatient);

--- a/src/models/helpers/Patient.ts
+++ b/src/models/helpers/Patient.ts
@@ -1,4 +1,4 @@
-import { Patient, CreatePatientDTO, ParentRelation, ParentDTO } from '../schemas';
+import { Patient, CreatePatientDTO } from '../schemas';
 import { nanoid } from 'nanoid/non-secure';
 
 export namespace PatientHelpers {
@@ -46,18 +46,6 @@ export namespace PatientHelpers {
       .map((n) => n[0])
       .join('')
       .toUpperCase();
-  }
-
-  export function getPrimaryContact(patient: Patient): string | undefined {
-    return patient.contact.email || patient.contact.tel;
-  }
-
-  export function getMotherInfo(patient: Patient): ParentDTO | undefined {
-    return patient.parents.find((p) => p.relation === ParentRelation.MOTHER);
-  }
-
-  export function getFatherInfo(patient: Patient): ParentDTO | undefined {
-    return patient.parents.find((p) => p.relation === ParentRelation.FATHER);
   }
 
   export function getFormattedBirthdate(patient: Patient): string {

--- a/src/models/schemas/patientSchema.ts
+++ b/src/models/schemas/patientSchema.ts
@@ -1,3 +1,4 @@
+import { DAY_IN_MONTHS, MAX_AGE_IN_MONTH_IN_PEDIATRIC } from '@/constants';
 import * as v from 'valibot';
 
 export enum ParentRelation {
@@ -56,6 +57,20 @@ export const patientSchema = v.object({
       (date) => new Date(date) <= new Date(),
       'La date de naissance ne peut pas être dans le futur',
     ),
+    v.check(
+      (date) => {
+        const now = new Date();
+        const birthDate = new Date(date);
+        const diffInMs = now.getTime() - birthDate.getTime();
+        return (
+          Math.floor(diffInMs / (1000 * 60 * 60 * 24)) / DAY_IN_MONTHS <=
+          MAX_AGE_IN_MONTH_IN_PEDIATRIC
+        );
+      },
+      'Ce patient ne peux être enrégistré en pediatrie. Il a plus ' +
+        Math.floor(MAX_AGE_IN_MONTH_IN_PEDIATRIC / 12) +
+        ' ans',
+    ),
   ),
   sex: v.enum(Sex, 'Le sex du patient est invalide'),
   isLocked: v.optional(v.boolean(), false),
@@ -102,6 +117,20 @@ export const createPatientSchema = v.object({
       (date) => new Date(date) <= new Date(),
       'La date de naissance ne peut pas être dans le futur',
     ),
+    v.check(
+      (date) => {
+        const now = new Date();
+        const birthDate = new Date(date);
+        const diffInMs = now.getTime() - birthDate.getTime();
+        return (
+          Math.floor(diffInMs / (1000 * 60 * 60 * 24)) / DAY_IN_MONTHS <=
+          MAX_AGE_IN_MONTH_IN_PEDIATRIC
+        );
+      },
+      'Ce patient ne peux être enrégistré en pediatrie. Il a plus de ' +
+        Math.floor(MAX_AGE_IN_MONTH_IN_PEDIATRIC / 12) +
+        ' ans',
+    ),
   ),
   sex: v.enum(Sex, 'Le sex du patient est invalide'),
   contact: v.optional(contactSchema),
@@ -131,6 +160,20 @@ export const updatePatientSchema = v.object({
       v.check(
         (date) => new Date(date) <= new Date(),
         'La date de naissance ne peut pas être dans le futur',
+      ),
+      v.check(
+        (date) => {
+          const now = new Date();
+          const birthDate = new Date(date);
+          const diffInMs = now.getTime() - birthDate.getTime();
+          return (
+            Math.floor(diffInMs / (1000 * 60 * 60 * 24)) / DAY_IN_MONTHS <=
+            MAX_AGE_IN_MONTH_IN_PEDIATRIC
+          );
+        },
+        'Ce patient ne peux être enrégistré en pediatrie. Il a plus de ' +
+          Math.floor(MAX_AGE_IN_MONTH_IN_PEDIATRIC / 12) +
+          ' ans',
       ),
     ),
   ),


### PR DESCRIPTION
- Add age limit validation to patient schemas to restrict pediatric registrations
- Convert age difference calculation to use days and months constants
- Update form submission to handle both add and update with typed data transfer objects
- Log success messages and navigate back after patient add/update operations
- Remove unused helper functions related to parent info retrieval
- Import and use DAY_IN_MONTHS constant for correct age calculations in validation and hooks